### PR TITLE
#163038470 Ft post confirm attendance implemented

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -6,7 +6,9 @@ api = Api(version_one)
 
 from .views.meetup_views import Meetup, MeetupId
 from .views.question_views import Question
+from .views.confirm_views import ConfirmAttendance
 
 api.add_resource(Meetup, '/meetups')
 api.add_resource(MeetupId, '/meetups/<int:id>')
 api.add_resource(Question, '/meetups/<int:id>/questions')
+api.add_resource(ConfirmAttendance, '/meetups/<int:id>/confirms')

--- a/app/api/v1/models/confirm_models.py
+++ b/app/api/v1/models/confirm_models.py
@@ -1,0 +1,16 @@
+import datetime
+confirm_record = []
+
+class ConfirmRecord():
+    def __init__(self):
+        self.rec  = confirm_record
+
+    def save(self, meetup_id, confirm):
+        data = {
+        "confirm_id": len(confirm_record) + 1,
+        "meetup_id": meetup_id,
+        "posted-on": datetime.datetime.now(),
+        "confirm_models": confirm
+        }
+        confirm_record.append(data)
+        return confirm_record

--- a/app/api/v1/views/confirm_views.py
+++ b/app/api/v1/views/confirm_views.py
@@ -1,0 +1,14 @@
+from flask_restful import Resource
+from flask import jsonify, make_response, request
+
+from ..models.confirm_models import ConfirmRecord
+class ConfirmAttendance(ConfirmRecord, Resource):
+    def __init__(self):
+        self.records = ConfirmRecord()
+
+    def post(self, id):
+        data = request.get_json()
+        meetup_id = id
+        confirm = data['confirm']
+        responce = self.records.save(meetup_id, confirm)
+        return make_response(jsonify({"A new confirm Attendance record has been created with the following details": responce}), 201)

--- a/app/tests/v1/test_confirm.py
+++ b/app/tests/v1/test_confirm.py
@@ -1,0 +1,23 @@
+from app import create_app
+from run import app
+from flask.testing import FlaskClient
+import unittest
+import json
+
+class TestConfirm(unittest.TestCase):
+    def setUp(self):
+         app.testing = True
+         self.app = create_app()
+         self.client = self.app.test_client()
+    def create_record(self):
+        new_rec = {
+        "confirm": "Yes?"
+        }
+        response = self.client.post('/api/v1/meetups/4/confirms',
+                            data=json.dumps(new_rec),
+                            headers={"content-type": "application/json"})
+        return response
+
+    def test_confirm_post(self):
+        r = self.create_record()
+        self.assertEqual(r.status_code, 201)


### PR DESCRIPTION
**What does this PR do?**
Creates the POST confirm attendance endpoint

**Description of the task to be completed**
Create a failing test for the POST confirm attendance endpoint
Create a POST confirm attendance endpoint
**How can this be manually tested?**
clone this repo https://github.com/SamueGathua/Questioner.git
cd Questioner
Create a virtual environment virtualenv -p python3
Activate the environment source myenv/bin/activate
Run the application flask run.
Test the endpoint on Postman
**What are the relevant PT stories**
#163038470
![screenshot from 2019-01-10 02-10-26](https://user-images.githubusercontent.com/45825874/50935392-edd26680-147c-11e9-9740-e2f5e9e3599d.png)
